### PR TITLE
Updated regex and added several tests

### DIFF
--- a/sample.php
+++ b/sample.php
@@ -28,10 +28,16 @@ T12: '''<dfn>[http://example.com Lorem ipsum]</dfn>''' This test includes a link
 
 T13: '''<dfn>[http://example.com Lorem ipsum]</dfn>''' This test includes a link in the dfn and a [http://example.com/path/to/test.html more complicated link] in the text. It is also multiple sentences long.
 
+T14: '''<dfn>post</dfn>''' can refer to either: <ul><li> A discreet piece of content (perhaps a <a href="/note" title="note">note</a> or and <a href="/article" title="article">article</a>) — see also <a href="/posts" title="posts">posts</a>
+</li><li> The act of creating the aforementioned content
+<ul><li> Also used elsewhere, e.g "posted a comment", "posted a photo"
+</li></ul>
+</li></ul>
+
 <?php
 $text = ob_get_clean();
 
-if ( preg_match_all('/.*<dfn>.+<\/dfn>.+?[\.!\?](?=\s|$)/', $text, $matches) )
+if ( preg_match_all('/.*<dfn>.+<\/dfn>.+?[\.:!\?](?=\s|$)/', $text, $matches) )
 {
 
 	foreach ( $matches[0] as $match )


### PR DESCRIPTION
Note the lookahead (?=\s|$) which does not consume the extra space character after the end of the sentence.

Added question mark and exclamation mark to the end-of-sentence match. Removed the colon because in multiple tests it did not cause a problem; should be captured by the preceding .+?

Added unique test identifiers before each line to avoid double replacement.
